### PR TITLE
Fix missing WebApplication reference

### DIFF
--- a/src/Tradeflow.Api/Program.cs
+++ b/src/Tradeflow.Api/Program.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Builder;
+using Aspire.Hosting;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
## Summary
- add missing using directives for WebApplication/ServiceDefaults

## Testing
- `dotnet build src/Tradeflow.Api/Tradeflow.Api.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688a5f6661488323b9d209f2038f6954