### PR TITLE
Add gitignore and Visual Studio solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+# Ignore build outputs and Visual Studio files
+bin/
+obj/
+**/bin/
+**/obj/
+*.user
+*.suo
+*.userprefs
+*.csproj.user
+*.vcxproj.user
+*.vs/
+# Rider project files
+.idea/
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
+# Logs
+*.log
+# Visual Studio Code
+.vscode/
+# DotCover
+*.dotCover
+# Test results
+TestResults/
+# nuget packages folder
+packages/
+# Build artifacts
+*.nuget.props
+*.nuget.targets
+# Other .NET files
+*.dbmdl
+*.pdb
+*.cache
+
+# Node / React
+node_modules/
+dist/
+build/
+.env
+.env.*
+.npm/
+yarn.lock
+package-lock.json
+*.tsbuildinfo
+.eslintcache
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/Tradeflow.sln
+++ b/Tradeflow.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tradeflow.Api", "src/Tradeflow.Api/Tradeflow.Api.csproj", "{eeacd481-bd2e-4024-8c9b-ee68ae914b6f}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{eeacd481-bd2e-4024-8c9b-ee68ae914b6f}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{eeacd481-bd2e-4024-8c9b-ee68ae914b6f}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{eeacd481-bd2e-4024-8c9b-ee68ae914b6f}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{eeacd481-bd2e-4024-8c9b-ee68ae914b6f}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- add repo-wide `.gitignore` for common .NET and React artifacts
- introduce `Tradeflow.sln` to open project in Visual Studio

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688a60a62f7c832386f710df0a99643b