### PR TITLE
Fix AddServiceDefaults error

### DIFF
--- a/src/Tradeflow.Api/Tradeflow.Api.csproj
+++ b/src/Tradeflow.Api/Tradeflow.Api.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="8.0.0-preview.4" />
+    <PackageReference Include="Aspire.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- bump `Aspire.Hosting` to 8.0.0 so `AddServiceDefaults` is available

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688a6287a8f8832395395905dfce1f7e